### PR TITLE
Can now add custom fields and tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ logit
 Library to extend Log4J1.2 (and other logging frameworks) by providing a json layout (for logstash) and a zeromq appender (jeromq)
 This is my first real attack at a java project, so you have been warned!
 
-v0.1.0
+v0.2.0
 
 Log4j1
 ------
@@ -25,6 +25,8 @@ log4j.appender.A2.SendHWM=1000
 log4j.appender.A2.layout=com.stuartwarren.logit.log4j1.Layout
 log4j.appender.A2.layout.LayoutType=logstashv1
 log4j.appender.A2.layout.DetailThreshold=INFO
+log4j.appender.A2.layout.Tags=tag1,tag2,tag3
+log4j.appender.A2.layout.Fields=field1:value1,field2:value2,field3:value3
 ```
 __Configure ZMQ__
 
@@ -33,6 +35,14 @@ __Configure ZMQ__
 * Linger (Time to wait to close socket http://api.zeromq.org/3-2:zmq-setsockopt#toc13)
 * SendHWM (Messages to allow to queue up before block/drop http://api.zeromq.org/3-2:zmq-setsockopt#toc3)
 * Endpoints: protocol://hostname:port,protocol://hostname:port (Comma separated list)
+
+__Add optional tags/fields to every log__
+
+Simply follow this format:
+```
+log4j.appender.A2.layout.Tags=tag1,tag2,tag3
+log4j.appender.A2.layout.Fields=field1:value1,field2:value2,field3:value3
+```
 
 In your code, use log4j as normal (add objects to the MDC)
 ```
@@ -70,6 +80,8 @@ logback.xml
       <layout class="com.stuartwarren.logit.logback.Layout">
         <layoutType>logstashv1</layoutType>
         <detailThreshold>INFO</detailThreshold>
+        <tags>tag1,tag2,tag3</tags>
+        <fields>field1:value1,field2:value2,field3:value3</fields>
       </layout>
     </encoder>
   </appender>

--- a/src/main/java/com/stuartwarren/logit/gelf/v1/GelfV1Log.java
+++ b/src/main/java/com/stuartwarren/logit/gelf/v1/GelfV1Log.java
@@ -4,7 +4,7 @@
 package com.stuartwarren.logit.gelf.v1;
 
 import java.io.IOException;
-import java.util.ArrayList;
+//import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,7 +21,6 @@ import com.stuartwarren.logit.layout.Log;
 public final class GelfV1Log extends Log {
 
     private String                  version;
-    private ArrayList<String>       tags;
     private HashMap<String, Object> jacksonOutput;
 
     private ObjectMapper            mapper;
@@ -45,21 +44,6 @@ public final class GelfV1Log extends Log {
      */
     public void setVersion(String version) {
         this.version = version;
-    }
-
-    /**
-     * @return the tags
-     */
-    public ArrayList<String> getTags() {
-        return tags;
-    }
-
-    /**
-     * @param tags
-     *            the tags to set
-     */
-    public void setTags(ArrayList<String> tags) {
-        this.tags = tags;
     }
     
     private void addEventData(String key, Object val) {
@@ -85,6 +69,12 @@ public final class GelfV1Log extends Log {
     }
 
     public String toString() {
+        Map<String, Object> fields = this.getFields();
+        if (null != fields) {
+            for (Map.Entry<String, Object> entry : fields.entrySet()) {
+                addEventData(entry.getKey(), entry.getValue());
+            }
+        }
         Map<String, Object> mdc = this.getMdc();
         for (Map.Entry<String, Object> entry : mdc.entrySet()) {
             addEventData(entry.getKey(), entry.getValue());

--- a/src/main/java/com/stuartwarren/logit/layout/IFrameworkLayout.java
+++ b/src/main/java/com/stuartwarren/logit/layout/IFrameworkLayout.java
@@ -1,0 +1,54 @@
+/**
+ * 
+ */
+package com.stuartwarren.logit.layout;
+
+/**
+ * @author Stuart Warren 
+ * @date 7 Oct 2013
+ *
+ */
+public interface IFrameworkLayout {
+    
+    /**
+     * @return the layoutType
+     */
+    public String getLayoutType();
+
+    /**
+     * @param layoutType the layoutType to set
+     */
+    public void setLayoutType(String layoutType);
+
+    /**
+     * @return the detailThreshold
+     */
+    public String getDetailThreshold();
+
+    /**
+     * @param detailThreshold the detailThreshold to set
+     */
+    public void setDetailThreshold(String detailThreshold);
+    
+    /**
+     * @return the fields
+     */
+    public String getFields();
+
+    /**
+     * @param fields the fields to set
+     */
+    public void setFields(String fields);
+
+    /**
+     * @return the tags
+     */
+    public String getTags();
+
+    /**
+     * @param tags the tags to set
+     */
+    public void setTags(String tags);
+
+
+}

--- a/src/main/java/com/stuartwarren/logit/layout/Log.java
+++ b/src/main/java/com/stuartwarren/logit/layout/Log.java
@@ -3,6 +3,10 @@
  */
 package com.stuartwarren.logit.layout;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -15,13 +19,15 @@ public class Log {
     private long                    timestamp;
     private String                  ndc;
     private Map<String, Object>     mdc;
-    private ExceptionInformation           exceptionInformation;
-    private LocationInformation            locationInformation;
+    private ExceptionInformation    exceptionInformation;
+    private LocationInformation     locationInformation;
     private String                  level;
     private int                     level_int;
     private String                  loggerName;
     private String                  threadName;
     private String                  message;
+    private ArrayList<String>       tags;
+    private Map<String,Object>      fields;
 
     /**
      * @return the timestamp
@@ -205,6 +211,70 @@ public class Log {
     // return username;
     // }
     
+    /**
+     * @return the tags
+     */
+    public ArrayList<String> getTags() {
+        return tags;
+    }
+
+    /**
+     * @param tags 
+     *      the tags to set
+     */
+    public void setTags(String tags) {
+        // Split string on commas. Ignore whitespace.
+        if (null != tags) {
+            this.tags = new ArrayList<String>(Arrays.asList(tags.split("\\s*,\\s*")));
+        }
+    }
+    
+    /**
+     * @param tag 
+     *      the tag to add to the list
+     */
+    public void appendTag(String tag) {
+        if (null != tag) {
+            if (null == this.tags) {
+                this.tags = new ArrayList<String>();
+            }
+            this.tags.add(tag);
+        }
+    }
+
+    /**
+     * @return the fields
+     */
+    public Map<String,Object> getFields() {
+        return fields;
+    }
+
+    /**
+     * @param fields the fields to set
+     */
+    public void setFields(String fields) {
+        // Split string on : and ,
+        //eg field1:value,field2:value
+        if (null != fields) {
+            this.fields = new LinkedHashMap<String, Object>();
+                for(String keyValue : fields.split("\\s*,\\s*")) {
+                String[] pairs = keyValue.split("\\s*:\\s*", 2);
+                this.fields.put(pairs[0], pairs.length == 1 ? "" : pairs[1]);
+            }
+        }
+    }
+    
+    @SuppressWarnings("unchecked")
+    public void addField(String key, Object val) {
+        if (val instanceof HashMap) {
+            if (!((HashMap<String, Object>) val).isEmpty()) {
+                fields.put(key, val);
+            }
+        } else if (null != val) {
+            fields.put(key, val);
+        }
+    }
+
     public String toString() {
         StringBuffer strBuf = new StringBuffer();
         strBuf.append(getTimestamp());
@@ -224,6 +294,10 @@ public class Log {
         strBuf.append(getLoggerName());
         strBuf.append(' ');
         strBuf.append(getThreadName());
+        strBuf.append(' ');
+        strBuf.append(getTags());
+        strBuf.append(' ');
+        strBuf.append(getFields());
         return strBuf.toString();
     }
 

--- a/src/main/java/com/stuartwarren/logit/log4j1/Layout.java
+++ b/src/main/java/com/stuartwarren/logit/log4j1/Layout.java
@@ -12,6 +12,7 @@ import org.apache.log4j.spi.LoggingEvent;
 import org.apache.log4j.spi.ThrowableInformation;
 
 import com.stuartwarren.logit.layout.ExceptionInformation;
+import com.stuartwarren.logit.layout.IFrameworkLayout;
 import com.stuartwarren.logit.layout.LayoutFactory;
 import com.stuartwarren.logit.layout.LocationInformation;
 import com.stuartwarren.logit.layout.Log;
@@ -21,7 +22,7 @@ import com.stuartwarren.logit.layout.Log;
  * @date 6 Oct 2013
  *
  */
-public class Layout extends org.apache.log4j.Layout {
+public class Layout extends org.apache.log4j.Layout implements IFrameworkLayout {
     
     private String layoutType = "log";
     private Log log;
@@ -33,6 +34,8 @@ public class Layout extends org.apache.log4j.Layout {
     private LocationInfo info;
     private LocationInformation locationInfo;
     private ExceptionInformation exceptionInfo;
+    private String fields;
+    private String tags;
     
     
     public Layout() {
@@ -75,6 +78,9 @@ public class Layout extends org.apache.log4j.Layout {
         this.log.setLoggerName(event.getLoggerName());
         this.log.setThreadName(event.getThreadName());
         this.log.setMessage(event.getRenderedMessage());
+        this.log.setTags(tags);
+        this.log.setFields(fields);
+        this.log.appendTag("log4j");
         return this.log;
     }
     
@@ -160,6 +166,34 @@ public class Layout extends org.apache.log4j.Layout {
      */
     public void setDetailThreshold(String detailThreshold) {
         this.detailThreshold = detailThreshold;
+    }
+
+    /**
+     * @return the fields
+     */
+    public String getFields() {
+        return fields;
+    }
+
+    /**
+     * @param fields the fields to set
+     */
+    public void setFields(String fields) {
+        this.fields = fields;
+    }
+
+    /**
+     * @return the tags
+     */
+    public String getTags() {
+        return tags;
+    }
+
+    /**
+     * @param tags the tags to set
+     */
+    public void setTags(String tags) {
+        this.tags = tags;
     }
 
 }

--- a/src/main/java/com/stuartwarren/logit/logback/Layout.java
+++ b/src/main/java/com/stuartwarren/logit/logback/Layout.java
@@ -14,6 +14,7 @@ import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.LayoutBase;
 
 import com.stuartwarren.logit.layout.ExceptionInformation;
+import com.stuartwarren.logit.layout.IFrameworkLayout;
 import com.stuartwarren.logit.layout.LayoutFactory;
 import com.stuartwarren.logit.layout.LocationInformation;
 import com.stuartwarren.logit.layout.Log;
@@ -23,14 +24,17 @@ import com.stuartwarren.logit.layout.Log;
  * @date 6 Oct 2013
  *
  */
-public class Layout extends LayoutBase<ILoggingEvent> {
+public class Layout extends LayoutBase<ILoggingEvent> implements IFrameworkLayout {
     
     private String layoutType = "log";
+    private String detailThreshold = Level.ERROR.toString();
+    private String fields;
+    private String tags;
+    
     private Log log;
     private LayoutFactory layoutFactory;
     private LayoutFactory layout;
     
-    private String detailThreshold = Level.ERROR.toString();
     private boolean getLocationInfo = false;
     private StackTraceElement info;
     private LocationInformation locationInfo;
@@ -75,6 +79,9 @@ public class Layout extends LayoutBase<ILoggingEvent> {
         this.log.setLoggerName(event.getLoggerName());
         this.log.setThreadName(event.getThreadName());
         this.log.setMessage(event.getFormattedMessage());
+        this.log.setTags(tags);
+        this.log.setFields(fields);
+        this.log.appendTag("logback");
         return this.log;
     }
     
@@ -151,6 +158,34 @@ public class Layout extends LayoutBase<ILoggingEvent> {
      */
     public void setDetailThreshold(String detailThreshold) {
         this.detailThreshold = detailThreshold;
+    }
+
+    /**
+     * @return the fields
+     */
+    public String getFields() {
+        return fields;
+    }
+
+    /**
+     * @param fields the fields to set
+     */
+    public void setFields(String fields) {
+        this.fields = fields;
+    }
+
+    /**
+     * @return the tags
+     */
+    public String getTags() {
+        return tags;
+    }
+
+    /**
+     * @param tags the tags to set
+     */
+    public void setTags(String tags) {
+        this.tags = tags;
     }
 
 }

--- a/src/main/java/com/stuartwarren/logit/logstash/v0/LogstashV0Log.java
+++ b/src/main/java/com/stuartwarren/logit/logstash/v0/LogstashV0Log.java
@@ -4,7 +4,6 @@
 package com.stuartwarren.logit.logstash.v0;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 
 import org.codehaus.jackson.JsonGenerationException;
@@ -22,9 +21,7 @@ public final class LogstashV0Log extends Log {
 
     private long                    timestamp;
     private String                  version;
-    private ArrayList<String>       tags;
     private HashMap<String, Object> jacksonOutput;
-    private HashMap<String, Object> fields;
 
     private ObjectMapper            mapper;
 
@@ -32,7 +29,6 @@ public final class LogstashV0Log extends Log {
         super();
         this.mapper = new ObjectMapper();
         this.jacksonOutput = new HashMap<String, Object>();
-        this.fields = new HashMap<String, Object>();
     }
 
     /**
@@ -67,21 +63,6 @@ public final class LogstashV0Log extends Log {
         this.version = version;
     }
 
-    /**
-     * @return the tags
-     */
-    public ArrayList<String> getTags() {
-        return tags;
-    }
-
-    /**
-     * @param tags
-     *            the tags to set
-     */
-    public void setTags(ArrayList<String> tags) {
-        this.tags = tags;
-    }
-
     @SuppressWarnings("unchecked")
     private void addEventData(String key, Object val) {
         if (val instanceof HashMap) {
@@ -90,17 +71,6 @@ public final class LogstashV0Log extends Log {
             }
         } else if (null != val) {
             jacksonOutput.put(key, val);
-        }
-    }
-    
-    @SuppressWarnings("unchecked")
-    private void addField(String key, Object val) {
-        if (val instanceof HashMap) {
-            if (!((HashMap<String, Object>) val).isEmpty()) {
-                fields.put(key, val);
-            }
-        } else if (null != val) {
-            fields.put(key, val);
         }
     }
 
@@ -117,7 +87,7 @@ public final class LogstashV0Log extends Log {
         addField("location", this.getLocationInformation());
         addField("logger", this.getLoggerName());
         addField("level", this.getLevel());
-        addEventData("@fields", this.fields);
+        addEventData("@fields", this.getFields());
         try {
             log = mapper.writeValueAsString(jacksonOutput);
         } catch (JsonGenerationException e) {

--- a/src/main/java/com/stuartwarren/logit/logstash/v1/LogstashV1Log.java
+++ b/src/main/java/com/stuartwarren/logit/logstash/v1/LogstashV1Log.java
@@ -4,7 +4,6 @@
 package com.stuartwarren.logit.logstash.v1;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,7 +22,6 @@ public final class LogstashV1Log extends Log {
 
     private long                    timestamp;
     private String                  version;
-    private ArrayList<String>       tags;
     private HashMap<String, Object> jacksonOutput;
 
     private ObjectMapper            mapper;
@@ -64,21 +62,6 @@ public final class LogstashV1Log extends Log {
         this.version = version;
     }
 
-    /**
-     * @return the tags
-     */
-    public ArrayList<String> getTags() {
-        return tags;
-    }
-
-    /**
-     * @param tags
-     *            the tags to set
-     */
-    public void setTags(ArrayList<String> tags) {
-        this.tags = tags;
-    }
-
     @SuppressWarnings("unchecked")
     private void addEventData(String key, Object val) {
         if (val instanceof HashMap) {
@@ -92,7 +75,12 @@ public final class LogstashV1Log extends Log {
 
     public String toString() {
         String log;
-        // addEventData("mdc", this.getMdc());
+        Map<String, Object> fields = this.getFields();
+        if (null != fields) {
+            for (Map.Entry<String, Object> entry : fields.entrySet()) {
+                addEventData(entry.getKey(), entry.getValue());
+            }
+        }
         Map<String, Object> mdc = this.getMdc();
         for (Map.Entry<String, Object> entry : mdc.entrySet()) {
             addEventData(entry.getKey(), entry.getValue());

--- a/src/test/java/com/stuartwarren/test_logit/log4j1/LogIt.java
+++ b/src/test/java/com/stuartwarren/test_logit/log4j1/LogIt.java
@@ -26,7 +26,7 @@ public class LogIt {
 //        LogManager.shutdown();
 //        // System.exit(0);
         
-        MDC.put("tags", "other");
+        MDC.put("stuff", "other");
         logger.error("There's been an error", new NullPointerException("Fake error thrown"));
         System.exit(0);
         LogManager.shutdown();

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,5 +1,5 @@
 # Set root logger level to DEBUG and its only appender to A1.
-log4j.rootLogger=TRACE, A2
+log4j.rootLogger=TRACE, A3
 
 # A1 is set to be a ConsoleAppender.
 log4j.appender.A1=org.apache.log4j.ConsoleAppender
@@ -18,5 +18,7 @@ log4j.appender.A2.layout.DetailThreshold=INFO
 # A3 is the console appender with a Logstash json_event v1 layout
 log4j.appender.A3=org.apache.log4j.ConsoleAppender
 log4j.appender.A3.layout=com.stuartwarren.logit.log4j1.Layout
-log4j.appender.A3.layout.LayoutType=logstashv1
+log4j.appender.A3.layout.LayoutType=gelfv1
 log4j.appender.A3.layout.DetailThreshold=INFO
+log4j.appender.A3.layout.Tags=tag1,tag2,tag3
+log4j.appender.A3.layout.Fields=field1:value1,field2:value2,field3:value3


### PR DESCRIPTION
Fixes #1... finally!
Now able to add custom tags and fields to all logs in config file.
Comma separated list of tags
Comma separated list of key:value pairs for fields.

Very little testing but seems to work.
